### PR TITLE
Make this plugin platform independent

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -28,7 +28,7 @@
 
   <idea-version since-build="145.0"/>
   <depends>com.intellij.modules.lang</depends>
-  <depends>com.intellij.modules.java</depends>
+  <depends optional="true">com.intellij.modules.java</depends>
   <extensions defaultExtensionNs="com.intellij">
     <treeStructureProvider
         implementation="com.github.b3er.idea.plugins.arc.browser.ArchivePluginStructureProvider"/>


### PR DESCRIPTION
I'm not sure why this plugin depends on `com.intellij.modules.java`, but it works without it. So I thought I'd just make it at least optional.