### PR TITLE
Remove gz from SEVEN_ZIP_EXTENSIONS

### DIFF
--- a/src/main/kotlin/com/github/b3er/idea/plugins/arc/browser/plugin.kt
+++ b/src/main/kotlin/com/github/b3er/idea/plugins/arc/browser/plugin.kt
@@ -98,7 +98,6 @@ class ArchivePluginFileTypeFactory : FileTypeFactory() {
             "txz",
             "tlz",
             "gem",
-            "gz",
             "tar"
         )
         val ALL_EXTENSIONS = COMMON_ZIP_EXTENSIONS + ZIP_EXTENSIONS + SEVEN_ZIP_EXTENSIONS


### PR DESCRIPTION
gz is registered and handled separately by the GzipFileType.

Registering it for both makes Intellij keep reassigning it and warning the user.

Fixes #23